### PR TITLE
Add About Bolt page

### DIFF
--- a/src/Controller/Backend/GeneralController.php
+++ b/src/Controller/Backend/GeneralController.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Bolt\Controller\Backend;
+
+use Bolt\Controller\BaseController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class GeneralController extends BaseController
+{
+    /**
+     * @Route("/about", name="bolt_about")
+     */
+    public function about()
+    {
+        return $this->renderTemplate('about/about.twig', [
+            'controller_name' => 'GeneralController',
+        ]);
+    }
+}

--- a/templates/about/about.twig
+++ b/templates/about/about.twig
@@ -1,0 +1,53 @@
+{# Page: Footer > About #}
+
+{% extends '@bolt/_base/layout.twig' %}
+
+{% block title %} About Bolt » Sophisticated, lightweight & simple CMS {% endblock title %}
+
+
+{% block main %}
+
+    <div class="row">
+        <div class="col-md-9">
+            <h2>Bolt {{ constant('Bolt\\Version::VERSION') }}</h2>
+
+            <p>
+                Bolt is a CMS that strives to be simple, fast, straightforward and enjoyable to use. Both for
+                developers and content-editors. Bolt is Open Source, and as such it uses other Open Source
+                components. If you are a developer you're very welcome to help in the further development of Bolt.
+            </p>
+            <p>
+                All parts of Bolt are free to use under the open-source MIT license. The full licensing text can be
+                found here, in the included <a href="https://docs.bolt.cm/other/license">LICENSE.md</a>.
+            </p>
+
+            <p>
+                <a href="https://bolt.cm" class="btn btn-bolt" target="_blank">
+                    <i class="fa fa-external-link"></i> Visit Bolt.cm
+                </a>
+                <a href="https://docs.bolt.cm" class="btn btn-default" target="_blank">
+                    <i class="fa fa-external-link"></i> Bolt documentation
+                </a>
+                <a href="https://github.com/bolt/docs" class="btn btn-default" target="_blank">
+                    <i class="fa fa-github-alt"></i> Bolt on GitHub
+                </a>
+            </p>
+
+            <h3>Used Libraries / Components</h3>
+
+            <p>Below are the third party libraries that are used by Bolt. </p>
+
+            <ul>
+                <li>The awesome <a href="https://symfony.com/4">Symfony 4, PHP framework</a> and a lot of the
+                    <a href="http://symfony.com/">Symfony components</a>.</li>
+                <li>The <a href="http://www.doctrine-project.org">Doctrine DBAL</a> for database access and abstraction.</li>
+                <li><a href="http://twig.sensiolabs.org/">Twig, flexible, fast, and secure template engine</a>.</li>
+                <li><a href="http://twitter.github.com/bootstrap">Bootstrap 4</a> and
+                    <a href="http://fortawesome.github.com/Font-Awesome/">Font Awesome</a></li>
+                <li><a href="http://ckeditor.com/">CKEditor</a> for the clean HTML5 Wysywig editor areas.</li>
+            </ul>
+
+        </div>
+    </div>
+
+{% endblock main %}


### PR DESCRIPTION
This PR is just an "About Bolt page" base taken from Bolt 3 and it is related to #34 

The list of 3rd party libraries used by Bolt need to be updated. Not all of the technologies we are using to develop Bolt 4 are added yet and we might want to change the description text, plus a different styling if needed.

