### PR TITLE
Use Vue Components for Login Form

### DIFF
--- a/assets/js/Views/user.js
+++ b/assets/js/Views/user.js
@@ -5,6 +5,8 @@ import Vue from "vue";
 import Theme from "../Components/User/Theme";
 import Password from "../Components/Password/Password";
 import Email from "../Components/Email/Email";
+import Text from "../app/editor/Components/Editor/Text/Text";
+import Label from "../app/editor/Components/Editor/_Partials/Label";
 
 /**
  * Register Components
@@ -12,7 +14,16 @@ import Email from "../Components/Email/Email";
 Vue.component("user-theme", Theme);
 Vue.component("field-password", Password);
 Vue.component("field-email", Email);
+Vue.component("editor-text", Text);
+Vue.component("editor-label", Label);
 
-new Vue({ el: "#user", name: "user" });
-new Vue({ el: "#user-password", name: "field-password" });
-new Vue({ el: "#user-email", name: "field-password" });
+new Vue({
+    el: "#login-form",
+    name: "bolt-login",
+    components: {
+        "editor-text": Text,
+        "field-password": Password,
+        "editor-label": Label
+    }
+})
+

--- a/templates/_base/layout_blank.html.twig
+++ b/templates/_base/layout_blank.html.twig
@@ -19,7 +19,7 @@
         {% endblock %}
 
 {% block javascripts %}
-    <script src="{{ asset('assets/bolt.js') }}"></script>
+    {{ encore_entry_script_tags('bolt') }}
 {% endblock %}
 </body>
 

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -53,32 +53,30 @@
             </div>
         {% endif %}
 
-        <form action="{{ path('bolt_login') }}" method="post" class="">
+        <form action="{{ path('bolt_login') }}" method="post" class="" id="login-form">
+            {# TODO: Add _target_path hidden input as Vue Component #}
             <input type="hidden" name="_target_path" value="{{ app.request.get('redirect_to') }}"/>
+            {# TODO: Add _csrf_token hidden input as Vue Component #}
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}"/>
-
-            <div class="form-group">
-                <label for="username">{{ 'label.username_or_email'|trans }}</label>
-                <div class="input-group mb-3">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text"><i class="fas fa-user"></i> </span>
-                    </div>
-                    <input type="text" placeholder="{{ 'label.username'|trans }}" id="username" name="username" value="{{ last_username }}" class="form-control"/>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="password">{{ 'label.password'|trans }}</label>
-                <div class="input-group mb-3">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text"><i class="fas fa-key"></i></span>
-                    </div>
-                    <input type="password" placeholder="{{ 'label.password'|trans }}" id="password" name="password" class="form-control"/>
-                </div>
-            </div>
+            {% include '@bolt/_partials/fields/text.html.twig' with {
+                'label' : 'label.fullname'|trans,
+                'name' : 'username',
+                'value' : last_username,
+                'disabled' : false,
+            } %}
+            {% include '@bolt/_partials/fields/password.html.twig' with {
+                'label': 'label.password'|trans,
+                'label_class': 'required',
+                'name': 'password',
+                'value': '',
+                'class': 'form-control',
+            } %}
+            {# TODO: Add remember me checkbox as Vue Component #}
             <div class="form-group form-check">
                 <input type="checkbox" class="form-check-input" name="_remember_me" id="_remember_me">
                 <label class="form-check-label" for="_remember_me">{{ 'label.rememberme'|trans }}</label>
             </div>
+            {# TODO: Add submit button as Vue Component #}
             <button type="submit" class="btn btn-primary">
                 <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
                 {{ 'action.log_in'|trans }}


### PR DESCRIPTION
This PR uses the Password and Text Vue Components for the Login Form.

@JarJak @bobdenotter Maybe Vue Component fields should become more general?. 

The names they are using in the `.twig` files are forcing us to add components called like `editor-label`, `editor-text`, `editor-*` while they are not being part of the editcontent form anymore. In this case is a login form