### PR TITLE
Repair `setcontent`

### DIFF
--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -14,7 +14,7 @@ use Bolt\Storage\Query\SelectQuery;
  */
 class SelectQueryHandler
 {
-    public function __invoke(ContentQueryParser $contentQuery): ?QueryResultset
+    public function __invoke(ContentQueryParser $contentQuery)
     {
         $set = new QueryResultset();
         /** @var SelectQuery $query */

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -14,6 +14,9 @@ use Bolt\Storage\Query\SelectQuery;
  */
 class SelectQueryHandler
 {
+    /**
+     * @return Content|QueryResultSet|null
+     */
     public function __invoke(ContentQueryParser $contentQuery)
     {
         $set = new QueryResultset();

--- a/src/Storage/Query/Query.php
+++ b/src/Storage/Query/Query.php
@@ -72,6 +72,13 @@ class Query
      */
     public function getContentForTwig(string $textQuery, array $parameters = [])
     {
+        if (func_num_args() === 3) {
+            $whereparameters = func_get_arg(2);
+            if (is_array($whereparameters) && ! empty($whereparameters)) {
+                $parameters = array_merge($parameters, $whereparameters);
+            }
+        }
+
         return $this->getContentByScope('frontend', $textQuery, $parameters);
     }
 }

--- a/src/Storage/Query/Query.php
+++ b/src/Storage/Query/Query.php
@@ -70,14 +70,9 @@ class Query
     /**
      * Helper to be called from Twig that is passed via a TwigRecordsView rather than the raw records.
      */
-    public function getContentForTwig(string $textQuery, array $parameters = [])
+    public function getContentForTwig(string $textQuery, array $parameters = [], array $whereParameters = [])
     {
-        if (func_num_args() === 3) {
-            $whereparameters = func_get_arg(2);
-            if (is_array($whereparameters) && ! empty($whereparameters)) {
-                $parameters = array_merge($parameters, $whereparameters);
-            }
-        }
+        $parameters = array_merge($parameters, $whereParameters);
 
         return $this->getContentByScope('frontend', $textQuery, $parameters);
     }

--- a/src/Storage/Query/QueryParameterParser.php
+++ b/src/Storage/Query/QueryParameterParser.php
@@ -280,16 +280,16 @@ class QueryParameterParser
      *     'matched'  => <the pattern that the value matched>
      * ]
      *
-     * @param string $value Value to process
+     * @param $value Value to process
      *
      * @return array Parsed values
      */
-    public function parseValue(string $value): array
+    public function parseValue($value): array
     {
         foreach ($this->valueMatchers as $matcher) {
             $regex = sprintf('/%s/u', $matcher['token']);
             $values = $matcher['params'];
-            if (preg_match($regex, $value)) {
+            if (preg_match($regex, (string) $value)) {
                 if (is_callable($values['value'])) {
                     preg_match($regex, $value, $output);
                     $values['value'] = $values['value']($output[1]);


### PR DESCRIPTION
Fixes issues #282 and #283

This PR removes some type hints which is not a nice thing to do in general, but I don't know how to circumvent these issues in a nice way. Below is a summary.

**Notes**

- At the moment, `setcontent` can return `null` or `Content` for single item when using `{contenttype}/{id}` or `QueryResultSet` (empty or not) for multiple items.
  
  This was changed in https://github.com/bolt/four/commit/82244ab#diff-5ee7c092d66585260210d467fb97c416

- Function `parseValue` can get an integer when using `where { id: 1 }`.

  This was changed in https://github.com/bolt/four/commit/ce98e9bbaa993ba452d23bcae463f07178a3f3c6#diff-9501bf2bce92196e20149014404e59fb

- Function `getContentForTwig` actually gets three parameters:
  1. the base part like `pages` or `pages/1`
  2. parameters like `printquery`, `paging`
  3. actual `where` parameters taken from `... where { foo: bar } ...`

  This was changed in https://github.com/bolt/four/commit/1624cdc#diff-47ee526d7c161782611f5afd2e66c76d