### PR TITLE
[hotfix] Fix links in sidebar

### DIFF
--- a/assets/js/app/sidebar/Components/Menu/_SubMenu.vue
+++ b/assets/js/app/sidebar/Components/Menu/_SubMenu.vue
@@ -14,7 +14,6 @@
 </template>
 
 <script>
-import SubMenu from './_SubMenu';
 
 export default {
   name: "sub-menu",

--- a/src/Content/MenuBuilder.php
+++ b/src/Content/MenuBuilder.php
@@ -304,15 +304,8 @@ class MenuBuilder
                 foreach ($child->getChildren() as $submenuChild) {
                     $submenu[] = [
                         'name' => $submenuChild->getExtra('name') ?: $submenuChild->getLabel(),
-                        'singular_name' => $submenuChild->getExtra('singular_name'),
-                        'slug' => $submenuChild->getExtra('slug'),
-                        'singular_slug' => $submenuChild->getExtra('singular_slug'),
                         'icon' => $submenuChild->getExtra('icon'),
-                        'link' => $submenuChild->getUri(),
-                        'link_new' => $submenuChild->getExtra('link_new'),
-                        'contenttype' => $submenuChild->getExtra('contenttype'),
-                        'singleton' => $submenuChild->getExtra('singleton'),
-                        'type' => $submenuChild->getExtra('type'),
+                        'editLink' => $submenuChild->getUri(),
                         'active' => $submenuChild->getExtra('active'),
                     ];
                 }


### PR DESCRIPTION
Commit cfeff6def1af961e6e826fb5205bb489c6578065 introduced a new small bug: Sidebar items like `Configuration > Users&Permissions` need an `editLink` instead of a `link`. 