### PR TITLE
Fix tabbar

### DIFF
--- a/assets/scss/modules/editor/_tabbar.scss
+++ b/assets/scss/modules/editor/_tabbar.scss
@@ -7,6 +7,10 @@
   .nav-item {
     color: var(--shade);
     position: relative;
+  }
+
+  .nav-link {
+    padding: $spacer / 2 $spacer / 1.5;
 
     &::after {
       transition: $transition-base;
@@ -30,8 +34,7 @@
       font-weight: $font-weight-semibold;
     }
 
-    &.active,
-    &.show {
+    &.active {
       &::after {
         transform: scaleX(1);
       }
@@ -41,9 +44,5 @@
         color: var(--primary);
       }
     }
-  }
-
-  .nav-link {
-    padding: $spacer / 2 $spacer / 1.5;
   }
 }

--- a/templates/content/_tabs.html.twig
+++ b/templates/content/_tabs.html.twig
@@ -2,7 +2,7 @@
     <ul class="nav editor__tabbar" role="tablist">
         {% for group in groups %}
             <li class="nav-item">
-                <a class="nav-item nav-link {% if loop.first %}active{% endif %}" id="{{group|slug}}-tab" data-toggle="pill" href="#{{group|slug}}" role="tab" aria-controls="{{group|slug}}" aria-selected="{% if loop.first %}true{%else%}false{% endif %}">
+                <a class="nav-link {% if loop.first %}active{% endif %}" id="{{group|slug}}-tab" data-toggle="pill" href="#{{group|slug}}" role="tab" aria-controls="{{group|slug}}" aria-selected="{% if loop.first %}true{%else%}false{% endif %}">
                     <span>{{group|capitalize}}</span></a>
             </li>
         {% endfor %}


### PR DESCRIPTION
When you click the tab items in the editor, everything will be set to active state.

![image](https://user-images.githubusercontent.com/4630335/52218828-bb5d3300-289b-11e9-8359-ecbf9066ad13.png)



The correct ordering is:

```
[role=tablist] > li.nav-item > a.nav-link
```

See: https://getbootstrap.com/docs/4.0/components/navs/#javascript-behavior