### PR TITLE
Default escaping in fields

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -336,12 +336,10 @@ tests:
             uses: title
         text_markup:
             type: text
-            allow:
-                markup: true
+            allow_markup: true
         text_plain:
             type: text
-            allow:
-                markup: false
+            allow_markup: false
         selectfield:
             type: select
             values:

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -322,9 +322,10 @@ blocks:
     icon_one: "fa:cube"
 
 
-dummies:
-    name: Dummies
-    singular_name: Dummy
+# This contenttype is here to use for (automated) tests.
+tests:
+    name: Tests
+    singular_name: Test
     fields:
         title:
             type: text
@@ -333,6 +334,14 @@ dummies:
         slug:
             type: slug
             uses: title
+        text_markup:
+            type: text
+            allow:
+                markup: true
+        text_plain:
+            type: text
+            allow:
+                markup: false
         selectfield:
             type: select
             values:
@@ -345,6 +354,10 @@ dummies:
             multiple: true
             postfix: "Select your favourite turtle(s)."
     taxonomy: [ groups, categories, tags, foobars ]
+    record_template: test.twig
+    listing_template: listing.twig
+    listing_records: 10
+
 
 # Possible field types:
 #

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,6 +1,7 @@
 twig:
     debug: '%kernel.debug%'
     strict_variables: true
+    autoescape: false
     form_themes:
         - 'form/layout.twig'
         - 'form/fields.twig'

--- a/public/theme/skeleton/test.twig
+++ b/public/theme/skeleton/test.twig
@@ -2,6 +2,15 @@
 
 {% block main %}
 
+    <style>
+        .box {
+            display: inline-block;
+            border: 1px solid #CCC;
+            padding: 0.5em;
+            margin: 0.5em;
+        }
+    </style>
+
     <marquee>This template is for testing only! This template is for testing only! This template is for testing only!</marquee>
 
     {% if record.hasField('title') %}
@@ -12,16 +21,35 @@
 
     <hr>
 
-    <p class="text_markup_a">{{ record.text_markup }}</p>
-    <p class="text_markup_b">{{ record.text_markup|raw }}</p>
-    <p class="text_markup_c">{{ record.text_markup|e('html') }}</p>
-    <p class="text_markup_d">{{ dump(record.text_markup.getValue())}}</p>
+    <h2>Testing output with `allow_markup`</h2>
 
-    <p class="text_plain_a">{{ record.text_plain }}</p>
-    <p class="text_plain_b">{{ record.text_plain|raw }}</p>
-    <p class="text_plain_c">{{ record.text_plain|e('html') }}</p>
-    <p class="text_plain_d">{{ dump(record.text_plain.getValue())}}</p>
+    <p>
+        Default output with <code>allow_markup: {{ record.text_markup.definition.allow_markup ? 'true' : 'false' }}</code>:<br>
+        <span class="box text_markup_a">{{ record.text_markup }}</span><br>
 
+        Explicit raw: <br>
+        <span class="box text_markup_b">{{ record.raw('text_markup') }}</span><br>
+
+        Escaped: <br>
+        <span class="box text_markup_c">{{ record.escape('text_markup') }}</span><br>
+
+        {{ dump(record.text_plain.getValue())}}
+    </p>
+
+    <hr>
+
+    <p>
+        Default output with <code>allow_markup: {{ record.text_plain.definition.allow_markup ? 'true' : 'false' }}</code>:<br>
+        <span class="box text_plain_a">{{ record.text_plain }}</span><br>
+
+        Explicit raw: <br>
+        <span class="box text_plain_b">{{ record.raw('text_plain') }}</span><br>
+
+        Escaped: <br>
+        <span class="box text_plain_c">{{ record.escape('text_plain') }}</span><br>
+
+        {{ dump(record.text_plain.getValue())}}
+    </p>
 
     {% if record.hasField('image') %}
         <a href="{{ record.image }}">

--- a/public/theme/skeleton/test.twig
+++ b/public/theme/skeleton/test.twig
@@ -1,0 +1,44 @@
+{% extends 'partials/_master.twig' %}
+
+{% block main %}
+
+    <marquee>This template is for testing only! This template is for testing only! This template is for testing only!</marquee>
+
+    {% if record.hasField('title') %}
+        <h1 class="title">{{ record.title }}</h1>
+    {% else %}
+        <h1 class="heading">{{ record|title }}</h1>
+    {% endif %}
+
+    <hr>
+
+    <p class="text_markup_a">{{ record.text_markup }}</p>
+    <p class="text_markup_b">{{ record.text_markup|raw }}</p>
+    <p class="text_markup_c">{{ record.text_markup|e('html') }}</p>
+    <p class="text_markup_d">{{ dump(record.text_markup.getValue())}}</p>
+
+    <p class="text_plain_a">{{ record.text_plain }}</p>
+    <p class="text_plain_b">{{ record.text_plain|raw }}</p>
+    <p class="text_plain_c">{{ record.text_plain|e('html') }}</p>
+    <p class="text_plain_d">{{ dump(record.text_plain.getValue())}}</p>
+
+
+    {% if record.hasField('image') %}
+        <a href="{{ record.image }}">
+            <img src="{{ thumbnail(record.image, 400, 260) }}">
+        </a>
+        <hr>
+    {% endif %}
+
+    {# Output all fields, in the order as defined in the content type.
+       To change the generated html and configure the options, see:
+       https://docs.bolt.cm/templating #}
+    {% with { 'record': record, 'common': true, 'extended': true, 'repeaters': true, 'blocks': true } %}
+        {{ block('sub_fields', 'partials/_sub_fields.twig') }}
+    {% endwith %}
+
+    {{ dump(record) }}
+
+    {% include 'partials/_recordfooter.twig' with { 'record': record, 'extended': true } %}
+
+{% endblock main %}

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -209,6 +209,10 @@ class ContentTypesParser extends BaseParser
                 $hasGroups = true;
             }
 
+            if (! isset($field['allow_markup'])) {
+                $field['allow_markup'] = in_array($field['type'], ['html', 'markdown', 'textarea'], true);
+            }
+
             // Make sure we have these keys and every field has a group set.
             $field = array_replace(
                 [

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\DataFixtures;
 
+use Bolt\Collection\DeepCollection;
 use Bolt\Configuration\Config;
 use Bolt\Entity\Content;
 use Bolt\Entity\Field;
@@ -103,14 +104,14 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
         }
     }
 
-    private function getRandomStatus()
+    private function getRandomStatus(): string
     {
         $statuses = ['published', 'published', 'published', 'held', 'draft', 'timed'];
 
         return $statuses[array_rand($statuses)];
     }
 
-    private function getValuesforFieldType($name, $field)
+    private function getValuesforFieldType(string $name, DeepCollection $field): array
     {
         switch ($field['type']) {
             case 'html':
@@ -162,7 +163,7 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
         return $records;
     }
 
-    private function getPreset($slug): array
+    private function getPreset(string $slug): array
     {
         if (isset($this->presetRecords[$slug]) && ! empty($this->presetRecords[$slug])) {
             $preset = array_pop($this->presetRecords[$slug]);

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -28,9 +28,13 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
 
     private $lastTitle = null;
 
+    /** @var array */
+    private $presetRecords = [];
+
     public function __construct(Config $config)
     {
         $this->faker = Factory::create();
+        $this->presetRecords = $this->getPresetRecords();
         $this->config = $config->get('contenttypes');
     }
 
@@ -58,7 +62,7 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
             $amount = $contentType['singleton'] ? 1 : 15;
 
             foreach (range(1, $amount) as $i) {
-                $ref = $i === 0 ? 'admin' : ['admin', 'henkie', 'jane_admin', 'tom_admin'][random_int(0, 3)];
+                $ref = $i === 1 ? 'admin' : ['admin', 'henkie', 'jane_admin', 'tom_admin'][random_int(0, 3)];
                 /** @var User $author */
                 $author = $this->getReference($ref);
 
@@ -71,11 +75,18 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
                 $content->setPublishedAt($this->faker->dateTimeBetween('-1 year'));
                 $content->setDepublishedAt($this->faker->dateTimeBetween('-1 year'));
 
+                $preset = $this->getPreset($contentType['slug']);
+
                 $sortorder = 1;
                 foreach ($contentType['fields'] as $name => $fieldType) {
                     $field = Field::factory($fieldType, $name);
                     $field->setName($name);
-                    $field->setValue($this->getValuesforFieldType($name, $fieldType));
+
+                    if (isset($preset[$name])) {
+                        $field->setValue((array) $preset[$name]);
+                    } else {
+                        $field->setValue($this->getValuesforFieldType($name, $fieldType));
+                    }
                     $field->setSortorder($sortorder++ * 5);
 
                     $content->addField($field);
@@ -128,5 +139,37 @@ class ContentFixtures extends Fixture implements DependentFixtureInterface
         }
 
         return $data;
+    }
+
+    private function getPresetRecords(): array
+    {
+        $records['blocks'][] = [
+            'title' => 'About',
+        ];
+        $records['blocks'][] = [
+            'title' => 'Search',
+        ];
+
+        $records['tests'][] = [
+            'selectfield' => 'bar',
+            'multiselect' => 'Michelangelo',
+            'slug' => 'title-of-the-test',
+            'title' => 'Title of the test',
+            'text_markup' => 'Text with <em>markup allowed</em>.',
+            'text_plain' => 'Text with <strong>no</strong> markup allowed.',
+        ];
+
+        return $records;
+    }
+
+    private function getPreset($slug): array
+    {
+        if (isset($this->presetRecords[$slug]) && ! empty($this->presetRecords[$slug])) {
+            $preset = array_pop($this->presetRecords[$slug]);
+        } else {
+            $preset = [];
+        }
+
+        return $preset;
     }
 }

--- a/src/Entity/ContentExtrasTrait.php
+++ b/src/Entity/ContentExtrasTrait.php
@@ -71,4 +71,25 @@ trait ContentExtrasTrait
             'depublishedAt' => $content->getDepublishedAt(),
         ];
     }
+
+    public function var_export(): string
+    {
+        $array = $this->getFieldValues();
+
+        return var_export($array, true);
+    }
+
+    public function raw($fieldName): \Twig_Markup
+    {
+        $output = implode('', $this->getField($fieldName)->getValue());
+
+        return new \Twig_Markup($output, 'UTF-8');
+    }
+
+    public function escape($fieldName): string
+    {
+        $output = implode('', $this->getField($fieldName)->getValue());
+
+        return htmlentities($output);
+    }
 }

--- a/src/Entity/ContentExtrasTrait.php
+++ b/src/Entity/ContentExtrasTrait.php
@@ -79,14 +79,14 @@ trait ContentExtrasTrait
         return var_export($array, true);
     }
 
-    public function raw($fieldName): \Twig_Markup
+    public function raw(string $fieldName): \Twig_Markup
     {
         $output = implode('', $this->getField($fieldName)->getValue());
 
         return new \Twig_Markup($output, 'UTF-8');
     }
 
-    public function escape($fieldName): string
+    public function escape(string $fieldName): string
     {
         $output = implode('', $this->getField($fieldName)->getValue());
 

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -103,7 +103,13 @@ class Field implements Translatable
 
     public function __toString(): string
     {
-        return implode(', ', $this->getValue());
+        $stringValue = implode(', ', $this->getValue());
+
+        if (! $this->getDefinition()->get('allow_markup')) {
+            $stringValue = htmlentities($stringValue);
+        }
+
+        return $stringValue;
     }
 
     public static function factory(LaravelCollection $definition, string $name = ''): self

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -28,9 +28,9 @@
         {% set labels = jsonlabels(['about.bolt_documentation', 'action.visit_site', 'action.create_new', ['general.greeting', {'%name%': user_display_name}], 'action.logout', 'action.edit_profile']) %}
         <admin-toolbar
             site-name="{% if config is defined %}{{ config.get('general/sitename') }}{% endif %}"
-            :menu="{{ sidebarmenu() }}"
+            :menu="{{ sidebarmenu()|e }}"
             user="{{ user|default }}"
-            :labels="{{ labels|json_decode }}"
+            :labels="{{ labels|json_decode|e }}"
         ></admin-toolbar>
     </nav>
     <!-- End Admin Toolbar -->
@@ -49,9 +49,9 @@
     <div class="admin__sidebar">
         <div id="sidebar">
             <admin-sidebar
-              :menu="{{ sidebarmenu() }}"
+              :menu="{{ sidebarmenu()|e }}"
               :version="'{{ version|default('unknown')|replace({'alpha': 'α', 'beta': 'β'}) }}'"
-              :about-link="{{ path('bolt_about')|json_encode }}"
+              :about-link="{{ path('bolt_about')|json_encode|e }}"
             ></admin-sidebar >
         </div>
     </div>

--- a/templates/_partials/_content_listing.html.twig
+++ b/templates/_partials/_content_listing.html.twig
@@ -3,7 +3,7 @@
     <listing-records
       type="{{ type }}"
       {# tricky part: https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle/issues/165#issuecomment-462777227 #}
-      :data="{{ records|merge([])|json_encode }}"
+      :data="{{ records|merge([])|json_encode|e }}"
     >
     </listing-records>
     <!-- end listing records -->

--- a/templates/_partials/fields/email.html.twig
+++ b/templates/_partials/fields/email.html.twig
@@ -4,6 +4,6 @@
         <field-email
             :id="'{{ id }}'"
             :name="'{{ name }}'"
-            :value="{{ value|json_encode() }}"
+            :value="{{ value|json_encode()|e }}"
         ></field-email>
 {% endblock %}

--- a/templates/_partials/fields/html.html.twig
+++ b/templates/_partials/fields/html.html.twig
@@ -2,7 +2,7 @@
 
 {% block field %}
     <editor-html
-        :value="'{{ value|json_encode() }}'"
+        :value="{{ value|json_encode()|e }}"
         :name="'{{ name }}'"
     ></editor-html>
 {% endblock %}

--- a/templates/_partials/fields/markdown.html.twig
+++ b/templates/_partials/fields/markdown.html.twig
@@ -2,7 +2,7 @@
 
 {% block field %}
     <editor-markdown
-        :value="'{{value|json_encode()}}'"
+        :value='{{ value|json_encode()|e }}'
         :name="'{{ name }}'"
     ></editor-markdown>
 {% endblock %}

--- a/templates/_partials/fields/password.html.twig
+++ b/templates/_partials/fields/password.html.twig
@@ -4,6 +4,6 @@
         <field-password
             :id="'{{ id }}'"
             :name="'{{ name }}'"
-            :value="{{ value|json_encode() }}"
+            :value="{{ value|json_encode()|e }}"
         ></field-password>
 {% endblock %}

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -23,10 +23,10 @@
 {% block field %}
     {#<pre><code>{{ value|json_encode() }}</code></pre>#}
     <editor-select
-        :value="{{ value|json_encode() }}"
+        :value="{{ value|json_encode()|e }}"
         :name="'{{ name }}'"
         :id="'{{ id }}'"
-        :options="{{ options|json_encode() }}"
+        :options="{{ options|json_encode()|e }}"
         :form="'{{ form }}'"
         :multiple="{{ multiple }}"
         :allowempty="{{ allowempty }}"

--- a/templates/_partials/fields/text.html.twig
+++ b/templates/_partials/fields/text.html.twig
@@ -8,7 +8,7 @@
 {% block field %}
     <editor-text
         :id="'{{ id }}'"
-        :value="{{ value|json_encode() }}"
+        :value="{{ value|json_encode()|e }}"
         :name="'{{ name }}'"
         :type="'{{ class }}'"
         :disabled="'{{ disabled }}'"

--- a/templates/_partials/fields/textarea.html.twig
+++ b/templates/_partials/fields/textarea.html.twig
@@ -2,7 +2,7 @@
 
 {% block field %}
     <editor-textarea
-        :value='{{ value|json_encode() }}'
+        :value='{{ value|json_encode()|e }}'
         :label="'{{ label }}'"
         :name="'{{ name }}'"
     ></editor-textarea>

--- a/templates/content/_localeswitcher.html.twig
+++ b/templates/content/_localeswitcher.html.twig
@@ -6,7 +6,7 @@
             <general-language
                     label="{{ 'field.switch_to_locale'|trans }}"
                     current="{{ currentlocale }}"
-                    :locales="{{ contentlocales(locales) }}"
+                    :locales="{{ contentlocales(locales)|e }}"
             ></general-language>
 
             <a href="{{ path('bolt_content_edit_locales', {'id': record.id}) }}" class="btn btn-light btn-small">

--- a/tests/e2e/features/display_record_test.feature
+++ b/tests/e2e/features/display_record_test.feature
@@ -1,0 +1,15 @@
+Feature: Test field output
+
+    Scenario: As a user I want to see how fields are escaped
+
+        When I visit the "single_test" page with parameters:
+            | slug | title-of-the-test |
+        Then I wait for "title" element to appear
+
+        And there is element "text_markup_a" with text "Text with markup allowed."
+        And there is element "text_markup_b" with text "Text with markup allowed."
+        And there is element "text_markup_c" with text "Text with <em>markup allowed</em>."
+
+        And there is element "text_plain_a" with text "Text with <strong>no</strong> markup allowed."
+        And there is element "text_plain_b" with text "Text with no markup allowed."
+        And there is element "text_plain_c" with text "Text with <strong>no</strong> markup allowed."

--- a/tests/e2e/pages/single_test.js
+++ b/tests/e2e/pages/single_test.js
@@ -1,0 +1,22 @@
+const { BasePage } = require('kakunin');
+
+class SingleTestPage extends BasePage {
+  constructor() {
+    super();
+
+    this.url = '/page/:slug';
+
+    this.title = $('h1.title');
+    this.heading = $('h1.heading');
+
+    this.text_markup_a = $('.text_markup_a');
+    this.text_markup_b = $('.text_markup_b');
+    this.text_markup_c = $('.text_markup_c');
+
+    this.text_plain_a = $('.text_plain_a');
+    this.text_plain_b = $('.text_plain_b');
+    this.text_plain_c = $('.text_plain_c');
+  }
+}
+
+module.exports = SingleTestPage;


### PR DESCRIPTION
Make field output like `{{ record.title }}` behave like we'd expect: 

1. "semantically pretty" as `{{ record.title }}` outputs HTML for fields where it makes sense ('html', 'markdown', 'textarea')
2. Add `allow_markup` flag to overrule the default behaviour in `contenttypes.yml`
3. add `.raw('foo')` and `.escape('foo')` methods to `Content` for fine-grained control in output.

Additionally, the PR adds a new way to preset records to be added, which is convenient for our automated tests.

See discussion in #351 