### PR TITLE
Ensure that we get unique random taxonomies for fixtures

### DIFF
--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -30,7 +30,7 @@ abstract class BaseFixture extends Fixture
         return $this->getReference($this->referencesIndex[$entityName][$randomReferenceKey]);
     }
 
-    protected function getRandomTaxonomy(string $type)
+    protected function getRandomTaxonomies(string $type, int $amount): array
     {
         if (empty($this->taxonomyIndex)) {
             foreach (array_keys($this->referenceRepository->getReferences()) as $key) {
@@ -42,11 +42,15 @@ abstract class BaseFixture extends Fixture
         }
 
         if (empty($this->taxonomyIndex[$type])) {
-            return null;
+            return [];
         }
 
-        $randomReferenceKey = array_rand($this->taxonomyIndex[$type], 1);
+        $taxonomies = [];
 
-        return $this->getReference($this->taxonomyIndex[$type][$randomReferenceKey]);
+        foreach ((array) array_rand($this->taxonomyIndex[$type], $amount) as $key) {
+            $taxonomies[] = $this->getReference($this->taxonomyIndex[$type][$key]);
+        }
+
+        return $taxonomies;
     }
 }

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -113,12 +113,8 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface
                         $taxonomyAmount = 1;
                     }
 
-                    for ($j = 1; $j <= $taxonomyAmount; $j++) {
-                        $taxonomy = $this->getRandomTaxonomy($taxonomySlug);
-
-                        if ($taxonomy) {
-                            $content->addTaxonomy($taxonomy);
-                        }
+                    foreach ($this->getRandomTaxonomies($taxonomySlug, $taxonomyAmount) as $taxonomy) {
+                        $content->addTaxonomy($taxonomy);
                     }
                 }
 

--- a/src/DataFixtures/TaxonomyFixtures.php
+++ b/src/DataFixtures/TaxonomyFixtures.php
@@ -51,7 +51,7 @@ class TaxonomyFixtures extends BaseFixture
         }
     }
 
-    private function getDefaultOptions()
+    private function getDefaultOptions(): array
     {
         $options = ['action', 'adult', 'adventure', 'alpha', 'animals', 'animation', 'anime', 'architecture', 'art',
             'astronomy', 'baby', 'batshitinsane', 'biography', 'biology', 'book', 'books', 'business',


### PR DESCRIPTION
This could cause tests to fail, randomly.. We test for "2 categories", but if the fixtures chose "Books" twice, it only stores one. This PR fixes that. 