### PR TITLE
Fix ECS deprecation notices

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -93,16 +93,16 @@ services:
 
 parameters:
     cache_directory: var/cache/ecs
-    exclude_checkers:
-        - 'PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer'
-        - 'PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer'
-        - 'PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer'
-        - 'PhpCsFixer\Fixer\Operator\ConcatSpaceFixer'
-        - 'PhpCsFixer\Fixer\Operator\IncrementStyleFixer'
-        - 'PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer'
-        - 'PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer'
-        - 'PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer'
-        - 'PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer'
-        - 'SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff'
-        - 'Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff' #to be removed before beta release
-        - 'Symplify\CodingStandard\Sniffs\Debug\DebugFunctionCallSniff' #to be removed before beta release
+    skip:
+        PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer: ~
+        PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer: ~
+        PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer: ~
+        PhpCsFixer\Fixer\Operator\ConcatSpaceFixer: ~
+        PhpCsFixer\Fixer\Operator\IncrementStyleFixer: ~
+        PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
+        PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer: ~
+        PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer: ~
+        PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer: ~
+        SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff: ~
+        Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff: ~ #to be removed before beta release
+        Symplify\CodingStandard\Sniffs\Debug\DebugFunctionCallSniff: ~ #to be removed before beta release


### PR DESCRIPTION
Every time we ran ECS, it'd say:

```
$ vendor/bin/ecs check src --fix
PHP Deprecated:  Parameter "exclude_checkers" is deprecated. Use "skip > CheckerClass: ~"
instead. in /Users/bob/Sites/four/vendor/symplify/easy-coding-standard/src/ DependencyInjection/CompilerPass/RemoveExcludedCheckersCompilerPass.php on line 36

Deprecated: Parameter "exclude_checkers" is deprecated. Use "skip > CheckerClass: ~" instead. 
in /Users/bob/Sites/four/vendor/symplify/easy-coding-standard/src/DependencyInjection/ 
CompilerPass/RemoveExcludedCheckersCompilerPass.php on line 36
EasyCodingStandard v5.4.16
```

This PR fixes that.