### PR TITLE
Add 'bolt.backend_url' parameter, so we can change it in one place.

### DIFF
--- a/assets/js/app/toolbar/Components/Toolbar.vue
+++ b/assets/js/app/toolbar/Components/Toolbar.vue
@@ -46,10 +46,10 @@
       <i class="fas fa-user mr-2"></i>{{ labels['general.greeting'] }}
       <ul class="toolbar--menu">
         <li>
-          <a href="/bolt/profile-edit">{{ labels['action.edit_profile'] }}</a>
+          <a :href="backend_prefix + 'profile-edit'">{{ labels['action.edit_profile'] }}</a>
         </li>
         <li>
-          <a href="/bolt/logout">{{ labels['action.logout'] }}</a>
+          <a :href="backend_prefix + 'logout'">{{ labels['action.logout'] }}</a>
         </li>
       </ul>
     </div>
@@ -61,7 +61,7 @@ const tinycolor = require('tinycolor2');
 
 export default {
   name: 'Toolbar',
-  props: ['siteName', 'menu', 'labels'],
+  props: ['siteName', 'menu', 'labels', 'backend_prefix'],
   computed: {
     contrast() {
       const color = tinycolor(this.toolbarColor);

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,7 +23,7 @@ security:
 
             logout:
                 path: bolt_logout
-                target: homepage
+                target: bolt_login
 
             remember_me:
                 secret: '%kernel.secret%'
@@ -32,7 +32,6 @@ security:
     access_control:
         # this is a catch-all for the admin area
         # additional security lives in the controllers
-        # @todo make admin area prefix configurable
-        - { path: '^/bolt/(login|resetpassword)$', roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: '^/bolt', roles: ROLE_ADMIN }
-        - { path: '^/(%app_locales%)/bolt', roles: ROLE_ADMIN }
+        - { path: '^%bolt.backend_url%/(login|resetpassword)$', roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: '^%bolt.backend_url%', roles: ROLE_ADMIN }
+        - { path: '^/(%app_locales%)%bolt.backend_url%', roles: ROLE_ADMIN }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -19,7 +19,7 @@ frontend:
 # Place your own routes here, that have a LOWER priority than the default routes.
 
 api_entrypoint:
-  path: /bolt/api # moved to admin area firewall
+  path: '%bolt.backend_url%/api'
   controller: api_platform.swagger.action.ui
 
 # ------------------------------------------------------------------------------
@@ -27,11 +27,11 @@ api_entrypoint:
 # to modify the `prefix` so the Control Panel can be accessed at a custom URL.
 control_panel_async:
   resource: '../src/Controller/Backend/Async'
-  prefix: /bolt/async # @todo make admin area prefix configurable
+  prefix: '%bolt.backend_url%/async'
 
 control_panel:
   resource: '../src/Controller/Backend/'
-  prefix: /bolt # @todo make admin area prefix configurable
+  prefix: '%bolt.backend_url%'
 
 # ------------------------------------------------------------------------------
 # Examples:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ parameters:
     doctrine.orm.entity_manager.class: Bolt\Doctrine\TranslatableEntityManager
     stof_doctrine_extensions.listener.translatable.class: Bolt\EventListener\PreTranslatableListener
     bolt.table_prefix: bolt_
+    bolt.backend_url: /bolt
 
 services:
     # default configuration for services in *this* file

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -31,6 +31,7 @@
             :menu="{{ sidebarmenu() }}"
             user="{{ user|default }}"
             :labels="{{ labels|json_decode }}"
+            :backend_prefix="{{ path('bolt_dashboard') }}"
         ></admin-toolbar>
     </nav>
     <!-- End Admin Toolbar -->


### PR DESCRIPTION
The backend url can be set in one location now, and i'm passing it into Vue. 

Fixes #245 
