### PR TITLE
Fixes #383

### DIFF
--- a/assets/js/app/sidebar/Components/Menu/index.vue
+++ b/assets/js/app/sidebar/Components/Menu/index.vue
@@ -17,12 +17,12 @@
         :href="item.link"
         class="admin__sidebar--link"
         :class="{
-          'has-menu': item.submenu !== null || item.contentType !== null,
+          'has-menu': item.submenu !== null || item.contenttype !== null,
         }"
       >
         <i class="fas mr-2 link--icon" :class="item.icon"></i
         ><span class="link--text">{{ item.name }}</span>
-        <template v-if="item.submenu !== null || item.contentType !== null">
+        <template v-if="item.submenu !== null || item.contenttype !== null">
           <i class="fas fa-caret-right link--caret"></i>
           <sub-menu :item="item"></sub-menu>
         </template>


### PR DESCRIPTION
This was a tricky one. I don't know if camelCase is how it's supposed to be, but it was causing a false positive while checking `item.contentType !== null`.