### PR TITLE
Fix integration with API Platform 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
-        "api-platform/core": "v2.4.0-beta.1",
+        "api-platform/core": "^2.4",
         "bolt/common": "^2.0.2",
         "cocur/slugify": "^3.1",
         "doctrine/annotations": "^1.0",
@@ -129,8 +129,7 @@
         ]
     },
     "conflict": {
-        "symfony/symfony": "*",
-        "api-platform/core": "v2.4.0-beta.2"
+        "symfony/symfony": "*"
     },
     "extra": {
         "symfony": {

--- a/config/services.xml
+++ b/config/services.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<!--
+This file overrides API Platform's ItemNormalizer service priority from -923 to -900.
+This is needed for API Platform to work since v2.4.0-beta.2 (in v2.4.0-beta.1 it worked well without it)
+For more information see:
+- API Platform issue: https://github.com/api-platform/api-platform/issues/1018
+- API Platform PR: https://github.com/api-platform/core/pull/2732
+- Bolt issue: https://github.com/bolt/four/pull/391#issuecomment-482798184
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="api_platform.serializer.normalizer.item" class="ApiPlatform\Core\Serializer\ItemNormalizer" public="false">
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.property_accessor" />
+            <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" on-invalid="ignore" />
+            <argument type="service" id="api_platform.item_data_provider" on-invalid="ignore" />
+            <argument>%api_platform.allow_plain_identifiers%</argument>
+            <argument>null</argument>
+            <argument type="tagged" tag="api_platform.data_transformer" on-invalid="ignore" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" on-invalid="ignore" />
+            <argument>false</argument>
+
+            <!-- After the DataUriNormalizer but before the ObjectNormalizer -->
+            <tag name="serializer.normalizer" priority="-900" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
This PR overrides API Platform's ItemNormalizer service priority from -923 to -900.
This is needed for API Platform to work since v2.4.0-beta.2 (in v2.4.0-beta.1 it worked well without it)
For more information see:
- API Platform issue: https://github.com/api-platform/api-platform/issues/1018
- API Platform PR: https://github.com/api-platform/core/pull/2732
- Bolt issue: https://github.com/bolt/four/pull/391#issuecomment-482798184