### PR TITLE
[hotfix] Make sure `{{ config }}` is set

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -7,3 +7,5 @@ twig:
     paths:
         '%kernel.project_dir%/public/theme/%bolt.theme%': ''
         '%kernel.project_dir%/templates/': 'bolt'
+    globals:
+        'config': '@Bolt\Configuration\Config'

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -46,9 +46,7 @@ class TwigAwareController extends AbstractController
      */
     protected function renderTemplate($template, array $parameters = [], ?Response $response = null): Response
     {
-        // Set config and version.
-        $parameters['config'] = $parameters['config'] ?? $this->config;
-        $parameters['version'] = $parameters['version'] ?? Version::VERSION;
+        // Set User in global Twig environment
         $parameters['user'] = $parameters['user'] ?? $this->getUser();
 
         // Resolve string|array of templates into the first one that is found.

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -6,7 +6,6 @@ namespace Bolt\Controller;
 
 use Bolt\Configuration\Config;
 use Bolt\Entity\Field\TemplateselectField;
-use Bolt\Version;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Tightenco\Collect\Support\Collection;

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -39,7 +39,7 @@
         }|json_encode %}
 
         <admin-toolbar
-            site-name="{{ config.get('general/sitename') }}"
+            site-name="{% if config is defined %}{{ config.get('general/sitename') }}{% endif %}"
             :menu="{{ admin_menu_json }}"
             user="{{ user|default }}"
             :labels="{{ labels }}"

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -39,7 +39,7 @@
         }|json_encode %}
 
         <admin-toolbar
-            site-name="{% if config is defined %}{{ config.get('general/sitename') }}{% endif %}"
+            site-name="{{ config.get('general/sitename') }}"
             :menu="{{ admin_menu_json }}"
             user="{{ user|default }}"
             :labels="{{ labels }}"
@@ -63,7 +63,7 @@
         <div id="sidebar">
             <admin-sidebar
               :menu="{{ admin_menu_json }}"
-              :version="'{{ version|default('unknown')|replace({'alpha': 'α', 'beta': 'β'}) }}'"
+              :version="'{{ constant('Bolt\\Version::VERSION')|replace({'alpha': 'α', 'beta': 'β'}) }}'"
               :about-link="{{ path('bolt_about')|json_encode }}"
             ></admin-sidebar >
         </div>

--- a/tests/e2e/features/backend_api.feature
+++ b/tests/e2e/features/backend_api.feature
@@ -1,4 +1,4 @@
-Feature: Visiting Dashboard
+Feature: Visiting API backend page
 
     Scenario: As an admin I want to see API page
         Given I am logged in as "admin"

--- a/tests/e2e/features/backend_api.feature
+++ b/tests/e2e/features/backend_api.feature
@@ -1,0 +1,7 @@
+Feature: Visiting Dashboard
+
+    Scenario: As an admin I want to see API page
+        Given I am logged in as "admin"
+        When I visit the "backend_api" page
+        Then there is element "header" with text "Bolt API"
+

--- a/tests/e2e/features/backend_translations.feature
+++ b/tests/e2e/features/backend_translations.feature
@@ -1,6 +1,6 @@
 Feature: Visiting Translations page
 
-    Scenario: As an admin I want to see API page
+    Scenario: As an admin I want to see Translations page
         Given I am logged in as "admin"
         When I visit the "backend_translations" page
         Then there is element "header" with text "Edit Translations"

--- a/tests/e2e/features/backend_translations.feature
+++ b/tests/e2e/features/backend_translations.feature
@@ -1,0 +1,7 @@
+Feature: Visiting Translations page
+
+    Scenario: As an admin I want to see API page
+        Given I am logged in as "admin"
+        When I visit the "backend_translations" page
+        Then there is element "header" with text "Edit Translations"
+

--- a/tests/e2e/features/frontend_menu.feature
+++ b/tests/e2e/features/frontend_menu.feature
@@ -6,7 +6,6 @@ Feature: Frontend menu
         And there is element "menu_last" with text "The Bolt site"
         And there are "eq 4" "menu_sub" elements
 
-    @wip
     Scenario: As a user I want to see the multi-level in the frontend
         When I visit the "single_test" page with parameters:
             | slug | title-of-the-test |

--- a/tests/e2e/pages/backend_api.js
+++ b/tests/e2e/pages/backend_api.js
@@ -1,0 +1,13 @@
+const { BasePage } = require('kakunin');
+
+class BackendApiPage extends BasePage {
+  constructor() {
+    super();
+
+    this.url = '/bolt/api';
+
+    this.header = $('.admin__header--title strong');
+  }
+}
+
+module.exports = BackendApiPage;

--- a/tests/e2e/pages/backend_translations.js
+++ b/tests/e2e/pages/backend_translations.js
@@ -1,0 +1,13 @@
+const { BasePage } = require('kakunin');
+
+class BackendTranslationsPage extends BasePage {
+  constructor() {
+    super();
+
+    this.url = '/bolt/_trans';
+
+    this.header = $('.admin__header--title');
+  }
+}
+
+module.exports = BackendTranslationsPage;


### PR DESCRIPTION
Fixes a regression in #404, where the API and translations screens don't show, because they don't use our controllers, and don't have our `config` set.

![Screenshot 2019-04-21 at 13 32 13](https://user-images.githubusercontent.com/1833361/56469443-3a451f00-643a-11e9-9b03-98bfa82fbeea.png)
