### PR TITLE
Expanding on fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,7 @@ csfix:
 	make csclear
 	vendor/bin/ecs check src --fix
 	vendor/bin/ecs check tests/spec --fix --config vendor/symplify/easy-coding-standard/config/common/namespaces.yml
-	vendor/bin/ecs check tests/php --fix --config vendor/symplify/easy-coding-standard/config/common/namespaces.yml
-	vendor/bin/ecs check tests/php --fix --config vendor/symplify/easy-coding-standard/config/common/phpunit.yml
-	vendor/bin/ecs check tests/php --fix --config vendor/symplify/easy-coding-standard/config/common/strict.yml
+	vendor/bin/ecs check tests/php --fix --config vendor/symplify/easy-coding-standard/config/common/namespaces.yml --config vendor/symplify/easy-coding-standard/config/common/phpunit.yml --config vendor/symplify/easy-coding-standard/config/common/strict.yml
 	make stancheck
 
 stancheck:

--- a/public/theme/skeleton/partials/_recordfooter.twig
+++ b/public/theme/skeleton/partials/_recordfooter.twig
@@ -40,7 +40,7 @@
         <ul>
             {% for content_type, related_records in related_content_types %}
                 <li>
-                    <h4>Related {{ app.config.contenttypes[content_type].name }}</h4>
+                    <h4>Related {{ config.get('contenttypes/' ~ content_type ~ '/name') }}</h4>
                     <ul>
                         {% for related_record in related_records %}
                             <li><a href="{{ related_record|link }}">{{ related_record|title }}</a></li>

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -14,6 +14,15 @@ abstract class BaseFixture extends Fixture
     private $referencesIndex = [];
     private $taxonomyIndex = [];
 
+    /**
+     * During unit-tests, the fixtures are ran multiple times. Flush the
+     * in-memory index, to prevent stale links to missing references.
+     */
+    protected function flushReferencesIndex(): void
+    {
+        $this->referencesIndex = [];
+    }
+
     protected function getRandomReference(string $entityName)
     {
         if (isset($this->referencesIndex[$entityName]) === false) {

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -10,6 +10,7 @@ use Bolt\Configuration\FileLocations;
 use Bolt\Entity\Content;
 use Bolt\Entity\Field;
 use Bolt\Enum\Statuses;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Factory;
@@ -18,7 +19,7 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 use Gedmo\Translatable\Entity\Translation;
 use Tightenco\Collect\Support\Collection;
 
-class ContentFixtures extends BaseFixture implements DependentFixtureInterface
+class ContentFixtures extends BaseFixture implements DependentFixtureInterface, FixtureGroupInterface
 {
     /** @var Generator */
     private $faker;
@@ -53,9 +54,14 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface
         ];
     }
 
+    public static function getGroups(): array
+    {
+        return ['with-images', 'without-images'];
+    }
+
     public function load(ObjectManager $manager): void
     {
-        $path = $this->fileLocations->get('files')->getBasepath() . '/stock/';
+        $path = $this->fileLocations->get('files')->getBasepath();
         $this->imagesIndex = $this->getImagesIndex($path);
 
         $this->loadContent($manager);

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -135,6 +135,9 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
                     }
                 }
 
+                $refKey = sprintf('content_%s_%s', $contentType['slug'], $content->getSlug());
+                $this->addReference($refKey, $content);
+
                 $manager->persist($content);
             }
         }

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -162,7 +162,7 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
             case 'file':
                 $randomImage = $this->imagesIndex->random();
                 $data = [
-                    'filename' => 'stock/' . $randomImage->getFilename(),
+                    'filename' => $randomImage->getRelativePathname(),
                     'alt' => $this->faker->sentence(4, true),
                     'title' => $this->faker->sentence(7, true),
                 ];

--- a/src/DataFixtures/ImageFetchFixtures.php
+++ b/src/DataFixtures/ImageFetchFixtures.php
@@ -19,7 +19,7 @@ class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
     private $fileLocations;
 
     private const AMOUNT = 10;
-    private const MAX_AMOUNT = 40;
+    private const MAX_AMOUNT = 50;
 
     public function __construct(FileLocations $fileLocations)
     {

--- a/src/DataFixtures/ImageFetchFixtures.php
+++ b/src/DataFixtures/ImageFetchFixtures.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\DataFixtures;
+
+use Bolt\Configuration\FileLocations;
+use Bolt\Factory\MediaFactory;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Factory;
+use Faker\Generator;
+use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
+
+class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
+{
+    /** @var Generator */
+    private $faker;
+
+    /** @var Collection */
+    private $urls;
+
+    /** @var MediaFactory */
+    private $mediaFactory;
+
+    /** @var FileLocations */
+    private $fileLocations;
+
+    private const AMOUNT = 10;
+    private const MAX_AMOUNT = 40;
+
+    public function __construct(FileLocations $fileLocations, MediaFactory $mediaFactory)
+    {
+        $this->urls = new Collection([
+            'https://source.unsplash.com/1280x1024/?business,workspace,interior/',
+            'https://source.unsplash.com/1280x1024/?cityscape,landscape,nature/',
+            'https://source.unsplash.com/1280x1024/?animal,kitten,puppy,cute/',
+            'https://source.unsplash.com/1280x1024/?technology/',
+        ]);
+
+        $this->faker = Factory::create();
+        $this->mediaFactory = $mediaFactory;
+        $this->fileLocations = $fileLocations;
+    }
+
+    public static function getGroups(): array
+    {
+        return ['with-images'];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $path = $this->fileLocations->get('files')->getBasepath();
+
+        // We only fetch more images, if we're currently under the MAX_AMOUNT
+        if ($this->getImagesIndex($path)->count() <= self::MAX_AMOUNT) {
+            $this->fetchImages();
+        }
+    }
+
+    private function fetchImages(): void
+    {
+        $outputPath = $this->fileLocations->get('files')->getBasepath() . '/stock/';
+
+        if (! is_dir($outputPath)) {
+            mkdir($outputPath);
+        }
+
+        for ($i = 1; $i <= self::AMOUNT; $i++) {
+            $url = $this->urls->random() . random_int(10000, 99999);
+            $filename = 'image_' . random_int(10000, 99999) . '.jpg';
+
+            $client = new Client();
+            $resource = fopen($outputPath . $filename, 'w');
+            $client->request('GET', $url, ['sink' => $resource]);
+            echo ' image';
+        }
+    }
+}

--- a/src/DataFixtures/ImageFetchFixtures.php
+++ b/src/DataFixtures/ImageFetchFixtures.php
@@ -5,24 +5,15 @@ declare(strict_types=1);
 namespace Bolt\DataFixtures;
 
 use Bolt\Configuration\FileLocations;
-use Bolt\Factory\MediaFactory;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Faker\Factory;
-use Faker\Generator;
 use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
 
 class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
 {
-    /** @var Generator */
-    private $faker;
-
     /** @var Collection */
     private $urls;
-
-    /** @var MediaFactory */
-    private $mediaFactory;
 
     /** @var FileLocations */
     private $fileLocations;
@@ -30,7 +21,7 @@ class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
     private const AMOUNT = 10;
     private const MAX_AMOUNT = 40;
 
-    public function __construct(FileLocations $fileLocations, MediaFactory $mediaFactory)
+    public function __construct(FileLocations $fileLocations)
     {
         $this->urls = new Collection([
             'https://source.unsplash.com/1280x1024/?business,workspace,interior/',
@@ -39,8 +30,6 @@ class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
             'https://source.unsplash.com/1280x1024/?technology/',
         ]);
 
-        $this->faker = Factory::create();
-        $this->mediaFactory = $mediaFactory;
         $this->fileLocations = $fileLocations;
     }
 
@@ -74,7 +63,6 @@ class ImageFetchFixtures extends BaseFixture implements FixtureGroupInterface
             $client = new Client();
             $resource = fopen($outputPath . $filename, 'w');
             $client->request('GET', $url, ['sink' => $resource]);
-            echo ' image';
         }
     }
 }

--- a/src/DataFixtures/ImagesFixtures.php
+++ b/src/DataFixtures/ImagesFixtures.php
@@ -10,24 +10,17 @@ use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Factory;
 use Faker\Generator;
-use Illuminate\Support\Collection;
 
 class ImagesFixtures extends BaseFixture implements FixtureGroupInterface
 {
     /** @var Generator */
     private $faker;
 
-    /** @var Collection */
-    private $urls;
-
     /** @var MediaFactory */
     private $mediaFactory;
 
     /** @var FileLocations */
     private $fileLocations;
-
-    private const AMOUNT = 10;
-    private const MAX_AMOUNT = 40;
 
     public function __construct(FileLocations $fileLocations, MediaFactory $mediaFactory)
     {

--- a/src/DataFixtures/ImagesFixtures.php
+++ b/src/DataFixtures/ImagesFixtures.php
@@ -6,13 +6,13 @@ namespace Bolt\DataFixtures;
 
 use Bolt\Configuration\FileLocations;
 use Bolt\Factory\MediaFactory;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Factory;
 use Faker\Generator;
-use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
 
-class ImagesFixtures extends BaseFixture
+class ImagesFixtures extends BaseFixture implements FixtureGroupInterface
 {
     /** @var Generator */
     private $faker;
@@ -27,50 +27,31 @@ class ImagesFixtures extends BaseFixture
     private $fileLocations;
 
     private const AMOUNT = 10;
+    private const MAX_AMOUNT = 40;
 
     public function __construct(FileLocations $fileLocations, MediaFactory $mediaFactory)
     {
-        $this->urls = new Collection([
-            'https://source.unsplash.com/1280x1024/?business,workspace,interior/',
-            'https://source.unsplash.com/1280x1024/?cityscape,landscape,nature/',
-            'https://source.unsplash.com/1280x1024/?animal,kitten,puppy,cute/',
-            'https://source.unsplash.com/1280x1024/?technology/',
-        ]);
-
         $this->faker = Factory::create();
         $this->mediaFactory = $mediaFactory;
         $this->fileLocations = $fileLocations;
     }
 
+    public static function getGroups(): array
+    {
+        return ['with-images', 'without-images'];
+    }
+
     public function load(ObjectManager $manager): void
     {
-        $this->fetchImages();
+        // Regardless of whether we fetch images, we still populate the Media Entities
         $this->loadImages($manager);
 
         $manager->flush();
     }
 
-    private function fetchImages(): void
-    {
-        $outputPath = $this->fileLocations->get('files')->getBasepath() . '/stock/';
-
-        if (! is_dir($outputPath)) {
-            mkdir($outputPath);
-        }
-
-        for ($i = 1; $i <= self::AMOUNT; $i++) {
-            $url = $this->urls->random() . random_int(10000, 99999);
-            $filename = 'image_' . random_int(10000, 99999) . '.jpg';
-
-            $client = new Client();
-            $resource = fopen($outputPath . $filename, 'w');
-            $client->request('GET', $url, ['sink' => $resource]);
-        }
-    }
-
     private function loadImages(ObjectManager $manager): void
     {
-        $path = $this->fileLocations->get('files')->getBasepath() . '/stock/';
+        $path = $this->fileLocations->get('files')->getBasepath();
 
         $index = $this->getImagesIndex($path);
 

--- a/src/DataFixtures/RelationsFixtures.php
+++ b/src/DataFixtures/RelationsFixtures.php
@@ -16,7 +16,7 @@ class RelationsFixtures extends BaseFixture implements DependentFixtureInterface
     /** @var Config */
     private $config;
 
-    public const AMOUNT = 8;
+    public const AMOUNT = 15;
 
     public function __construct(Config $config)
     {
@@ -57,7 +57,7 @@ class RelationsFixtures extends BaseFixture implements DependentFixtureInterface
         }
     }
 
-    private function addRelation($contentTypeFrom, $contentTypeTo, $manager): void
+    private function addRelation(string $contentTypeFrom, string $contentTypeTo, ObjectManager $manager): void
     {
         /** @var Content $contentFrom */
         $contentFrom = $this->getRandomReference('content_' . $contentTypeFrom);

--- a/src/DataFixtures/RelationsFixtures.php
+++ b/src/DataFixtures/RelationsFixtures.php
@@ -39,6 +39,8 @@ class RelationsFixtures extends BaseFixture implements DependentFixtureInterface
 
     public function load(ObjectManager $manager): void
     {
+        $this->flushReferencesIndex();
+
         $this->loadContent($manager);
 
         $manager->flush();

--- a/src/DataFixtures/TaxonomyFixtures.php
+++ b/src/DataFixtures/TaxonomyFixtures.php
@@ -8,9 +8,10 @@ use Bolt\Collection\DeepCollection;
 use Bolt\Configuration\Config;
 use Bolt\Entity\Taxonomy;
 use Bolt\Utils\Str;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class TaxonomyFixtures extends BaseFixture
+class TaxonomyFixtures extends BaseFixture implements FixtureGroupInterface
 {
     /** @var Config */
     private $config;
@@ -25,6 +26,11 @@ class TaxonomyFixtures extends BaseFixture
         $this->loadTaxonomies($manager);
 
         $manager->flush();
+    }
+
+    public static function getGroups(): array
+    {
+        return ['with-images', 'without-images'];
     }
 
     private function loadTaxonomies(ObjectManager $manager): void

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Bolt\DataFixtures;
 
 use Bolt\Entity\User;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
-class UserFixtures extends BaseFixture
+class UserFixtures extends BaseFixture implements FixtureGroupInterface
 {
     /** @var UserPasswordEncoderInterface */
     private $passwordEncoder;
@@ -23,6 +24,11 @@ class UserFixtures extends BaseFixture
         $this->loadUsers($manager);
 
         $manager->flush();
+    }
+
+    public static function getGroups(): array
+    {
+        return ['with-images', 'without-images'];
     }
 
     private function loadUsers(ObjectManager $manager): void

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -185,6 +185,15 @@ class Content
             throw new \RuntimeException('Content not fully initialized');
         }
 
+        return $this->getDefinition()->get('slug');
+    }
+
+    public function getContentTypeSingularSlug(): string
+    {
+        if ($this->getDefinition() === null) {
+            throw new \RuntimeException('Content not fully initialized');
+        }
+
         return $this->getDefinition()->get('singular_slug');
     }
 

--- a/src/Repository/RelationRepository.php
+++ b/src/Repository/RelationRepository.php
@@ -76,7 +76,6 @@ class RelationRepository extends SortableRepository
             ->join('r.toContent', 'cto')
             ->orderBy('r.position', 'DESC');
 
-
         if ($publishedOnly === true) {
             $qb->andWhere('cto.status = :status')
                 ->setParameter('status', Statuses::PUBLISHED, \PDO::PARAM_STR);

--- a/src/Repository/RelationRepository.php
+++ b/src/Repository/RelationRepository.php
@@ -6,6 +6,7 @@ namespace Bolt\Repository;
 
 use Bolt\Entity\Content;
 use Bolt\Entity\Relation;
+use Bolt\Enum\Statuses;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Sortable\Entity\Repository\SortableRepository;
@@ -33,15 +34,15 @@ class RelationRepository extends SortableRepository
     /**
      * @var Relation[]
      */
-    public function findRelations(Content $from, ?string $name, bool $biDirectional = false, ?int $limit = null): array
+    public function findRelations(Content $from, ?string $name, bool $biDirectional = false, ?int $limit = null, bool $publishedOnly = true): array
     {
-        $result = $this->buildRelationQuery($from, $name)
+        $result = $this->buildRelationQuery($from, $name, false, $publishedOnly)
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
 
         if (empty($result) === true && $biDirectional === true) {
-            $result = $this->buildRelationQuery($from, $name, true)
+            $result = $this->buildRelationQuery($from, $name, true, $publishedOnly)
                 ->setMaxResults($limit)
                 ->getQuery()
                 ->getResult();
@@ -50,15 +51,15 @@ class RelationRepository extends SortableRepository
         return $result;
     }
 
-    public function findFirstRelation(Content $from, ?string $name, bool $biDirectional = false): ?Relation
+    public function findFirstRelation(Content $from, ?string $name, bool $biDirectional = false, bool $publishedOnly = true): ?Relation
     {
-        $result = $this->buildRelationQuery($from, $name)
+        $result = $this->buildRelationQuery($from, $name, false, $publishedOnly)
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
 
         if ($result === null && $biDirectional === true) {
-            $result = $this->buildRelationQuery($from, $name, true)
+            $result = $this->buildRelationQuery($from, $name, true, $publishedOnly)
                 ->setMaxResults(1)
                 ->getQuery()
                 ->getOneOrNullResult();
@@ -67,13 +68,19 @@ class RelationRepository extends SortableRepository
         return $result;
     }
 
-    private function buildRelationQuery(Content $from, ?string $name, bool $reversed = false): QueryBuilder
+    private function buildRelationQuery(Content $from, ?string $name, bool $reversed = false, bool $publishedOnly = true): QueryBuilder
     {
         $qb = $this->createQueryBuilder('r')
             ->select('r, cfrom, cto')
             ->join('r.fromContent', 'cfrom')
             ->join('r.toContent', 'cto')
             ->orderBy('r.position', 'DESC');
+
+
+        if ($publishedOnly === true) {
+            $qb->andWhere('cto.status = :status')
+                ->setParameter('status', Statuses::PUBLISHED, \PDO::PARAM_STR);
+        }
 
         if ($name !== null) {
             $qb->andWhere('r.name = :name')

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -198,7 +198,7 @@ class ContentExtension extends AbstractExtension
 
         return $this->urlGenerator->generate('record', [
             'slugOrId' => $content->getSlug() ?: $content->getId(),
-            'contentTypeSlug' => $content->getContentTypeSlug(),
+            'contentTypeSlug' => $content->getContentTypeSingularSlug(),
         ], $absolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 

--- a/src/Twig/RelatedExtension.php
+++ b/src/Twig/RelatedExtension.php
@@ -51,9 +51,9 @@ class RelatedExtension extends AbstractExtension
     /**
      * @return array name => Content[]
      */
-    public function getAllRelatedContent(Content $content, bool $bidirectional = true, ?int $limit = null): array
+    public function getAllRelatedContent(Content $content, bool $bidirectional = true, ?int $limit = null, bool $publishedOnly = true): array
     {
-        $relations = $this->relationRepository->findRelations($content, null, $bidirectional, $limit);
+        $relations = $this->relationRepository->findRelations($content, null, $bidirectional, $limit, $publishedOnly);
 
         return (new Collection($relations))
             ->reduce(function (array $result, Relation $relation) use ($content): array {
@@ -71,11 +71,11 @@ class RelatedExtension extends AbstractExtension
     /**
      * @return Content[]
      */
-    public function getRelatedContent(Content $content, ?string $name = null, ?string $ct = null, bool $bidirectional = true, ?int $limit = null): array
+    public function getRelatedContent(Content $content, ?string $name = null, ?string $ct = null, bool $bidirectional = true, ?int $limit = null, bool $publishedOnly = true): array
     {
         $name = $name ?? $ct;
 
-        $relations = $this->relationRepository->findRelations($content, $name, $bidirectional, $limit);
+        $relations = $this->relationRepository->findRelations($content, $name, $bidirectional, $limit, $publishedOnly);
 
         return (new Collection($relations))
             ->map(function (Relation $relation) use ($content) {
@@ -85,11 +85,11 @@ class RelatedExtension extends AbstractExtension
             ->toArray();
     }
 
-    public function getFirstRelatedContent(Content $content, ?string $name = null, ?string $ct = null, bool $bidirectional = true): ?Content
+    public function getFirstRelatedContent(Content $content, ?string $name = null, ?string $ct = null, bool $bidirectional = true, bool $publishedOnly = true): ?Content
     {
         $name = $name ?? $ct;
 
-        $relation = $this->relationRepository->findFirstRelation($content, $name, $bidirectional);
+        $relation = $this->relationRepository->findFirstRelation($content, $name, $bidirectional, $publishedOnly);
 
         if ($relation === null) {
             return null;

--- a/tests/php/Repository/TaxonomyRepositoryTest.php
+++ b/tests/php/Repository/TaxonomyRepositoryTest.php
@@ -14,12 +14,10 @@ class TaxonomyRepositoryTest extends DbAwareTestCase
 {
     protected function setUp(): void
     {
-        $this->markTestIncomplete("This test takes like forever to run so let's skip it until it will be finished");
-
         parent::setUp();
 
         // fixtures loading takes a lot of time, it would be better to load database dump for tests
-        self::runCommand('doctrine:fixtures:load --no-interaction');
+        self::runCommand('doctrine:fixtures:load --no-interaction --group=without-images');
     }
 
     public function testSearchByType(): void

--- a/tests/spec/Bolt/Twig/ContentExtensionSpec.php
+++ b/tests/spec/Bolt/Twig/ContentExtensionSpec.php
@@ -136,7 +136,7 @@ class ContentExtensionSpec extends ObjectBehavior
         )->shouldBeCalled()->willReturn(self::TEST_LINK);
         $content->getId()->shouldBeCalled()->willReturn(self::TEST_ID);
         $content->getSlug()->shouldBeCalled()->willReturn(self::TEST_SLUG);
-        $content->getContentTypeSlug()->shouldBeCalled()->willReturn(self::TEST_CT_SLUG);
+        $content->getContentTypeSingularSlug()->shouldBeCalled()->willReturn(self::TEST_CT_SLUG);
 
         $this->getLink($content)->shouldBe(self::TEST_LINK);
     }
@@ -153,7 +153,7 @@ class ContentExtensionSpec extends ObjectBehavior
         )->shouldBeCalled()->willReturn(self::TEST_FULL_LINK);
         $content->getId()->shouldBeCalled()->willReturn(self::TEST_ID);
         $content->getSlug()->shouldBeCalled()->willReturn(null);
-        $content->getContentTypeSlug()->shouldBeCalled()->willReturn(self::TEST_CT_SLUG);
+        $content->getContentTypeSingularSlug()->shouldBeCalled()->willReturn(self::TEST_CT_SLUG);
 
         $this->getLink($content, true)->shouldBe(self::TEST_FULL_LINK);
     }

--- a/tests/spec/Bolt/Twig/RelatedExtensionSpec.php
+++ b/tests/spec/Bolt/Twig/RelatedExtensionSpec.php
@@ -22,7 +22,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_gets_all_related_content(Content $content, RelationRepository $relationRepository, Relation $relation, Content $related)
     {
-        $relationRepository->findRelations($content, null, true, null)
+        $relationRepository->findRelations($content, null, true, null, true)
             ->shouldBeCalledOnce()
             ->willReturn([$relation, $relation]);
 
@@ -42,7 +42,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_gets_related_content(Content $content, RelationRepository $relationRepository, Relation $relation, Content $related)
     {
-        $relationRepository->findRelations($content, self::TEST_CT_SLUG, true, null)
+        $relationRepository->findRelations($content, self::TEST_CT_SLUG, true, null, true)
             ->shouldBeCalledOnce()
             ->willReturn([$relation]);
 
@@ -58,7 +58,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_gets_related_content_unidirectional_with_limit(Content $content, RelationRepository $relationRepository, Relation $relation, Content $related)
     {
-        $relationRepository->findRelations($content, self::TEST_CT_SLUG, false, 3)
+        $relationRepository->findRelations($content, self::TEST_CT_SLUG, false, 3, true)
             ->shouldBeCalledOnce()
             ->willReturn([$relation, $relation, $relation]);
 
@@ -67,7 +67,7 @@ class RelatedExtensionSpec extends ObjectBehavior
         $content->getId()->willReturn(self::ORIGIN_ID);
         $related->getId()->willReturn(self::RELATED_ID);
 
-        $result = $this->getRelatedContent($content, null, self::TEST_CT_SLUG, false, 3);
+        $result = $this->getRelatedContent($content, null, self::TEST_CT_SLUG, false, 3, true);
         $result->shouldBeArray();
         $result->shouldHaveCount(3);
         $result[0]->shouldBeAnInstanceOf(Content::class);
@@ -75,7 +75,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_gets_first_related_content(Content $content, RelationRepository $relationRepository, Relation $relation, Content $related)
     {
-        $relationRepository->findFirstRelation($content, self::TEST_CT_SLUG, true, null)
+        $relationRepository->findFirstRelation($content, self::TEST_CT_SLUG, true, true)
             ->shouldBeCalledOnce()
             ->willReturn($relation);
 
@@ -90,7 +90,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_couldnt_find_related_content(Content $content, RelationRepository $relationRepository)
     {
-        $relationRepository->findRelations($content, null, true, null)->willReturn([]);
+        $relationRepository->findRelations($content, null, true, null, true)->willReturn([]);
         $result = $this->getRelatedContent($content);
         $result->shouldBeArray();
         $result->shouldHaveCount(0);
@@ -98,7 +98,7 @@ class RelatedExtensionSpec extends ObjectBehavior
 
     function it_couldnt_find_first_related_content(Content $content, RelationRepository $relationRepository)
     {
-        $relationRepository->findFirstRelation($content, null, true)->willReturn(null);
+        $relationRepository->findFirstRelation($content, null, true, true)->willReturn(null);
         $result = $this->getFirstRelatedContent($content);
         $result->shouldBeNull();
     }


### PR DESCRIPTION
 - Adding Relations as fixtures
 - Adding `with-images` and `without-images` groups, to speed up fixtures, if more images are not needed
 - Removing 'risky' tests, using them with `--group=without-images` instead. 


Also fixes #252, because tests broke now that Fixtures have relations