### PR TITLE
Allow for caching of widgets

### DIFF
--- a/src/Widget/BaseWidget.php
+++ b/src/Widget/BaseWidget.php
@@ -15,6 +15,7 @@ abstract class BaseWidget implements WidgetInterface
     use TwigTrait;
     use RequestTrait;
     use ResponseTrait;
+    use CacheTrait;
 
     /** @var string */
     protected $name;
@@ -33,6 +34,9 @@ abstract class BaseWidget implements WidgetInterface
 
     /** @var ?string */
     protected $slug;
+
+    /** @var int duration (in seconds) to cache output */
+    protected $cacheDuration = 600;
 
     public function setName(string $name): self
     {
@@ -137,5 +141,10 @@ abstract class BaseWidget implements WidgetInterface
         }
 
         return $this->slug;
+    }
+
+    public function getCacheDuration(): int
+    {
+        return $this->cacheDuration;
     }
 }

--- a/src/Widget/BaseWidget.php
+++ b/src/Widget/BaseWidget.php
@@ -15,7 +15,6 @@ abstract class BaseWidget implements WidgetInterface
     use TwigTrait;
     use RequestTrait;
     use ResponseTrait;
-    use CacheTrait;
 
     /** @var string */
     protected $name;
@@ -84,7 +83,20 @@ abstract class BaseWidget implements WidgetInterface
         return $this->priority;
     }
 
+    /**
+     * Method to 'invoke' the widget. Simple wrapper around the 'run' method,
+     * which can be overridden in a custom Widget or trait
+     */
     public function __invoke(array $params = []): string
+    {
+        return $this->run($params);
+    }
+
+    /**
+     * Actual method that 'runs' the widget and returns the output. For reasons
+     * of extensibility: Do not call directly, but call `$widget()` to invoke.
+     */
+    protected function run(array $params = []): string
     {
         if (array_key_exists('template', $params)) {
             $this->setTemplate($params['template']);

--- a/src/Widget/CacheAware.php
+++ b/src/Widget/CacheAware.php
@@ -13,6 +13,4 @@ use Psr\SimpleCache\CacheInterface;
 interface CacheAware extends WidgetInterface
 {
     public function setCacheInterface(CacheInterface $config): void;
-
-    public function cachedInvoke(): string;
 }

--- a/src/Widget/CacheAware.php
+++ b/src/Widget/CacheAware.php
@@ -12,5 +12,5 @@ use Psr\SimpleCache\CacheInterface;
  */
 interface CacheAware extends WidgetInterface
 {
-    public function setCacheInterface(CacheInterface $config): void;
+    public function setCache(CacheInterface $config): void;
 }

--- a/src/Widget/CacheAware.php
+++ b/src/Widget/CacheAware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Widget;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Interface CacheAware - Widgets that make use of caching need to implement
+ * this interface, in order to have their contents cached.
+ */
+interface CacheAware extends WidgetInterface
+{
+    public function setCacheInterface(CacheInterface $config): void;
+
+    public function cachedInvoke(): string;
+}

--- a/src/Widget/CacheTrait.php
+++ b/src/Widget/CacheTrait.php
@@ -26,8 +26,7 @@ trait CacheTrait
             return $this->getFromCache();
         }
 
-        /** @var WidgetInterface $this */
-        $output = $this();
+        $output = $this->__invoke();
 
         $this->setToCache($output);
 

--- a/src/Widget/CacheTrait.php
+++ b/src/Widget/CacheTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Widget;
 
+use Bolt\Widget\Exception\WidgetException;
 use Psr\SimpleCache\CacheInterface;
 
 trait CacheTrait
@@ -20,13 +21,17 @@ trait CacheTrait
         $this->key = $this->createKey();
     }
 
-    public function cachedInvoke(): string
+    public function __invoke(array $params = []): string
     {
+        if (!$this->cache instanceof CacheInterface) {
+            throw new WidgetException('Widget of class '.self::class.' is not initialised properly. Make sure the Widget `implements CacheAware`.');
+        }
+
         if ($this->isCached()) {
             return $this->getFromCache();
         }
 
-        $output = $this->__invoke();
+        $output = $this->run($params);
 
         $this->setToCache($output);
 

--- a/src/Widget/CacheTrait.php
+++ b/src/Widget/CacheTrait.php
@@ -15,7 +15,7 @@ trait CacheTrait
     /** @var string */
     private $key;
 
-    public function setCacheInterface(CacheInterface $cache): void
+    public function setCache(CacheInterface $cache): void
     {
         $this->cache = $cache;
         $this->key = $this->createKey();

--- a/src/Widget/CacheTrait.php
+++ b/src/Widget/CacheTrait.php
@@ -23,8 +23,8 @@ trait CacheTrait
 
     public function __invoke(array $params = []): string
     {
-        if (!$this->cache instanceof CacheInterface) {
-            throw new WidgetException('Widget of class '.self::class.' is not initialised properly. Make sure the Widget `implements CacheAware`.');
+        if (! $this->cache instanceof CacheInterface) {
+            throw new WidgetException('Widget of class ' . self::class . ' is not initialised properly. Make sure the Widget `implements CacheAware`.');
         }
 
         if ($this->isCached()) {

--- a/src/Widget/CacheTrait.php
+++ b/src/Widget/CacheTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Widget;
+
+use Psr\SimpleCache\CacheInterface;
+
+trait CacheTrait
+{
+    /** @var CacheInterface */
+    private $cache;
+
+    /** @var string */
+    private $key;
+
+    public function setCacheInterface(CacheInterface $cache): void
+    {
+        $this->cache = $cache;
+        $this->key = $this->createKey();
+    }
+
+    public function cachedInvoke(): string
+    {
+        if ($this->isCached()) {
+            return $this->getFromCache();
+        }
+
+        /** @var WidgetInterface $this */
+        $output = $this();
+
+        $this->setToCache($output);
+
+        return $output;
+    }
+
+    private function setToCache(string $output): void
+    {
+        $this->cache->set($this->key, $output, $this->getCacheDuration());
+    }
+
+    private function getFromCache(): string
+    {
+        return $this->cache->get($this->key);
+    }
+
+    private function isCached(): bool
+    {
+        return $this->cache->has($this->key);
+    }
+
+    private function createKey()
+    {
+        return $this->getName() . $this->getTarget() . $this->getZone() . $this->getPriority();
+    }
+}

--- a/src/Widget/NewsWidget.php
+++ b/src/Widget/NewsWidget.php
@@ -12,13 +12,14 @@ use Bolt\Widget\Injector\RequestZone;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
-class NewsWidget extends BaseWidget implements TwigAware, RequestAware
+class NewsWidget extends BaseWidget implements TwigAware, RequestAware, CacheAware
 {
     protected $name = 'News Widget';
     protected $target = AdditionalTarget::WIDGET_BACK_DASHBOARD_ASIDE_TOP;
     protected $priority = 150;
     protected $template = '@bolt/widgets/news.twig';
     protected $zone = RequestZone::BACKEND;
+    protected $cacheDuration = 3600;
 
     public function __invoke(array $params = []): string
     {

--- a/src/Widget/NewsWidget.php
+++ b/src/Widget/NewsWidget.php
@@ -14,6 +14,8 @@ use GuzzleHttp\Exception\RequestException;
 
 class NewsWidget extends BaseWidget implements TwigAware, RequestAware, CacheAware
 {
+    use CacheTrait;
+
     protected $name = 'News Widget';
     protected $target = AdditionalTarget::WIDGET_BACK_DASHBOARD_ASIDE_TOP;
     protected $priority = 150;
@@ -21,7 +23,7 @@ class NewsWidget extends BaseWidget implements TwigAware, RequestAware, CacheAwa
     protected $zone = RequestZone::BACKEND;
     protected $cacheDuration = 3600;
 
-    public function __invoke(array $params = []): string
+    protected function run(array $params = []): string
     {
         $news = $this->getNews();
 
@@ -35,7 +37,7 @@ class NewsWidget extends BaseWidget implements TwigAware, RequestAware, CacheAwa
             'datefetched' => '2019-04-04 07:25:00',
         ];
 
-        return parent::__invoke($context);
+        return parent::run($context);
     }
 
     /**

--- a/src/Widget/SnippetWidget.php
+++ b/src/Widget/SnippetWidget.php
@@ -27,7 +27,7 @@ class SnippetWidget extends BaseWidget
         $this->zone = $zone;
     }
 
-    public function run(array $params = []): string
+    protected function run(array $params = []): string
     {
         return $this->getTemplate();
     }

--- a/src/Widget/SnippetWidget.php
+++ b/src/Widget/SnippetWidget.php
@@ -27,7 +27,7 @@ class SnippetWidget extends BaseWidget
         $this->zone = $zone;
     }
 
-    public function __invoke(array $params = []): string
+    public function run(array $params = []): string
     {
         return $this->getTemplate();
     }

--- a/src/Widgets.php
+++ b/src/Widgets.php
@@ -91,8 +91,6 @@ class Widgets
 
         if ($widget instanceof CacheAware) {
             $widget->setCacheInterface($this->cache);
-
-            return $widget->cachedInvoke();
         }
 
         // Call the magic `__invoke` method on the $widget object

--- a/src/Widgets.php
+++ b/src/Widgets.php
@@ -90,7 +90,7 @@ class Widgets
         }
 
         if ($widget instanceof CacheAware) {
-            $widget->setCacheInterface($this->cache);
+            $widget->setCache($this->cache);
         }
 
         // Call the magic `__invoke` method on the $widget object

--- a/src/Widgets.php
+++ b/src/Widgets.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Bolt;
 
+use Bolt\Widget\CacheAware;
 use Bolt\Widget\Injector\QueueProcessor;
 use Bolt\Widget\Injector\RequestZone;
 use Bolt\Widget\RequestAware;
 use Bolt\Widget\TwigAware;
 use Bolt\Widget\WidgetInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -32,12 +34,16 @@ class Widgets
     /** @var Environment */
     private $twig;
 
-    public function __construct(RequestStack $requestStack, QueueProcessor $queueProcessor, Environment $twig)
+    /** @var CacheInterface */
+    private $cache;
+
+    public function __construct(RequestStack $requestStack, QueueProcessor $queueProcessor, Environment $twig, CacheInterface $cache)
     {
         $this->queue = new Collection([]);
         $this->requestStack = $requestStack;
         $this->queueProcessor = $queueProcessor;
         $this->twig = $twig;
+        $this->cache = $cache;
     }
 
     public function registerWidget(WidgetInterface $widget): void
@@ -56,11 +62,7 @@ class Widgets
         })->first();
 
         if ($widget) {
-            if ($widget instanceof RequestAware) {
-                $widget->setRequest($this->requestStack->getCurrentRequest());
-            }
-
-            return $widget($params);
+            return $this->invokeWidget($widget, $params);
         }
     }
 
@@ -75,14 +77,26 @@ class Widgets
         $output = '';
 
         foreach ($widgets as $widget) {
-            if ($widget instanceof RequestAware) {
-                $widget->setRequest($this->requestStack->getCurrentRequest());
-            }
-
-            $output .= $widget($params);
+            $output .= $this->invokeWidget($widget, $params);
         }
 
         return $output;
+    }
+
+    private function invokeWidget(WidgetInterface $widget, array $params = []): string
+    {
+        if ($widget instanceof RequestAware) {
+            $widget->setRequest($this->requestStack->getCurrentRequest());
+        }
+
+        if ($widget instanceof CacheAware) {
+            $widget->setCacheInterface($this->cache);
+
+            return $widget->cachedInvoke();
+        }
+
+        // Call the magic `__invoke` method on the $widget object
+        return $widget($params);
     }
 
     public function processQueue(Response $response): Response

--- a/tests/php/Widget/WidgetsTest.php
+++ b/tests/php/Widget/WidgetsTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TraceableAdapter;
+use Symfony\Component\Cache\Simple\Psr6Cache;
 use Twig\Loader\ArrayLoader;
 
 class WidgetsTest extends StringTestCase
@@ -33,7 +36,9 @@ class WidgetsTest extends StringTestCase
         $loader = new ArrayLoader(['weather.twig' => '[Hello, weather!]']);
         $twig = new Environment($loader);
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
         $response = new Response('<html><body>foo</body></html>');
 
         $snippet = (new SnippetWidget())
@@ -56,7 +61,9 @@ class WidgetsTest extends StringTestCase
         $loader = new ArrayLoader(['weather.twig' => '[Hello, weather!]']);
         $twig = new Environment($loader);
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
 
         $weatherWidget = new WeatherWidget();
         $weatherWidget->setTemplate('weather.twig');
@@ -79,7 +86,9 @@ class WidgetsTest extends StringTestCase
         $loader = new ArrayLoader(['weather.twig' => '[Hello, {{ foo }}!]']);
         $twig = new Environment($loader);
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
 
         $weatherWidget = new WeatherWidget();
         $weatherWidget->setTemplate('weather.twig');
@@ -102,7 +111,9 @@ class WidgetsTest extends StringTestCase
         $queueProcessor = new QueueProcessor(new HtmlInjector());
         $twig = new Environment(new ArrayLoader());
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
 
         $response = new Response('<html><body>foo</body></html>');
 
@@ -125,7 +136,9 @@ class WidgetsTest extends StringTestCase
         $loader = new ArrayLoader(['weather.twig' => '[Hello, weather!]']);
         $twig = new Environment($loader);
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
 
         $response = new Response('<html><body>foo</body></html>');
 
@@ -155,7 +168,9 @@ class WidgetsTest extends StringTestCase
         $loader = new ArrayLoader(['weather.twig' => '[Hello, weather!]']);
         $twig = new Environment($loader);
 
-        $widgets = new Widgets($requestStack, $queueProcessor, $twig);
+        $cache = new Psr6Cache(new TraceableAdapter(new FilesystemAdapter()));
+
+        $widgets = new Widgets($requestStack, $queueProcessor, $twig, $cache);
 
         $response = new Response('<html><body>foo</body></html>');
 

--- a/tests/php/Widget/WidgetsTest.php
+++ b/tests/php/Widget/WidgetsTest.php
@@ -13,13 +13,13 @@ use Bolt\Widget\Injector\Target;
 use Bolt\Widget\SnippetWidget;
 use Bolt\Widget\WeatherWidget;
 use Bolt\Widgets;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TraceableAdapter;
+use Symfony\Component\Cache\Simple\Psr6Cache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Adapter\TraceableAdapter;
-use Symfony\Component\Cache\Simple\Psr6Cache;
 use Twig\Loader\ArrayLoader;
 
 class WidgetsTest extends StringTestCase


### PR DESCRIPTION
Makes a big difference, especially for widgets like 'news'...

Before: 

![Screenshot 2019-05-09 at 22 02 39](https://user-images.githubusercontent.com/1833361/57483149-8f8c8780-72a6-11e9-96bd-92fd27669af7.png)

After: 

![Screenshot 2019-05-09 at 22 02 54](https://user-images.githubusercontent.com/1833361/57483188-95826880-72a6-11e9-907a-2e147471d8fe.png)
