### PR TITLE
Fix bug in injector where it confused tags like `head` and `header`

### DIFF
--- a/src/Widget/Injector/HtmlInjector.php
+++ b/src/Widget/Injector/HtmlInjector.php
@@ -224,7 +224,7 @@ class HtmlInjector
 
     private static function findTagEnd(string $rawHtml, string $htmlTag): ?string
     {
-        preg_match_all('~((<'.$htmlTag.'[^>]*?>)|(</'.$htmlTag.'>))~mi', $rawHtml, $allMatches);
+        preg_match_all('~((<'.$htmlTag.'(\s[^>]*)?>)|(</'.$htmlTag.'>))~mi', $rawHtml, $allMatches);
 
         if (empty($allMatches)) {
             return null;

--- a/tests/fixtures/HtmlInjector/index.html
+++ b/tests/fixtures/HtmlInjector/index.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_BODY_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_BODY_CSS.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_BODY_JS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_BODY_JS.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_CSS.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_HEAD_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_HEAD_CSS.html
@@ -11,6 +11,7 @@
 	koala
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_HEAD_JS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_HEAD_JS.html
@@ -11,6 +11,7 @@
 	koala
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_HEAD_META.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_HEAD_META.html
@@ -11,6 +11,7 @@
 	koala
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_HTML.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_HTML.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_JS.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_JS.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.AFTER_META.html
+++ b/tests/fixtures/HtmlInjector/result.AFTER_META.html
@@ -11,6 +11,7 @@
     koala
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_BODY_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_BODY_CSS.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 	koala
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_BODY_JS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_BODY_JS.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 	koala
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_CSS.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_CSS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_CSS.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_JS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_JS.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_META.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_HEAD_META.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_HTML.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_HTML.html
@@ -11,6 +11,7 @@ koala
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.BEFORE_JS.html
+++ b/tests/fixtures/HtmlInjector/result.BEFORE_JS.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.END_OF_BODY.html
+++ b/tests/fixtures/HtmlInjector/result.END_OF_BODY.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.END_OF_HEAD.html
+++ b/tests/fixtures/HtmlInjector/result.END_OF_HEAD.html
@@ -11,6 +11,7 @@
 	koala
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.END_OF_HTML.html
+++ b/tests/fixtures/HtmlInjector/result.END_OF_HTML.html
@@ -10,6 +10,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.START_OF_BODY.html
+++ b/tests/fixtures/HtmlInjector/result.START_OF_BODY.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 	koala
+    <header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/fixtures/HtmlInjector/result.START_OF_HEAD.html
+++ b/tests/fixtures/HtmlInjector/result.START_OF_HEAD.html
@@ -11,6 +11,7 @@
     <meta name="application-name" content="test">
 </head>
 <body>
+<header>This is a header element</header>
 <div>
     There can be only one!
 </div>

--- a/tests/php/Widget/Injector/HtmlInjectorTest.php
+++ b/tests/php/Widget/Injector/HtmlInjectorTest.php
@@ -81,7 +81,7 @@ class HtmlInjectorTest extends StringTestCase
     /**
      * @dataProvider providerTarget
      */
-    public function testInjectNoSpaces(string $constant): void
+    public function testInjectNoLinebreaks(string $constant): void
     {
         $expected = file_get_contents(self::TEST_TEMPLATES_BASE_PATH . 'result.' . $constant . '.html');
         $constant = constant('Bolt\Widget\Injector\Target::' . $constant);
@@ -89,7 +89,7 @@ class HtmlInjectorTest extends StringTestCase
 
         $snippet = new SnippetWidget('koala', '', $constant);
 
-        $response = new Response(preg_replace('/\s+/', '', $this->getHtml()));
+        $response = new Response(preg_replace('/(\r|\n)+/', '', $this->getHtml()));
         $injector->inject($snippet, $response);
 
         self::assertSameHtml($expected, $response->getContent());


### PR DESCRIPTION
Before: 

```html
<html lang="">
    <head>
                <title>Aliquam aut eos aspernatur ipsum accusamus. | Bolt Four Website</title>
        <link rel="stylesheet" href="/theme/skeleton/css/sakura.css">
    </head>
    <body>

        
            <!-- Header bar -->
<meta name="generator" content="Bolt"> <-- INCORRECT
<header>
        <h2><a href="/">Bolt Four Website</a></h2>
            <p>The amazing payoff goes here</p>
    
    <hr>
</header>

```

After: 

```html
<html lang="">
    <head>
                <title>Aliquam aut eos aspernatur ipsum accusamus. | Bolt Four Website</title>
        <link rel="stylesheet" href="/theme/skeleton/css/sakura.css">
    <meta name="generator" content="Bolt"> <-- CORRECT
    </head> . 
    <body>

        
            <!-- Header bar -->
<header>
        <h2><a href="/">Bolt Four Website</a></h2>
            <p>The amazing payoff goes here</p>
    
    <hr>
</header>
```

