### PR TITLE
Explicitly require `psr/simple-cache`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "nesbot/carbon": "^1.37",
         "php-translation/symfony-bundle": "^0.8",
         "phpdocumentor/reflection-docblock": "^4.3",
+        "psr/simple-cache": "^1.0",
         "sensio/framework-extra-bundle": "^5.3",
         "sensiolabs/security-checker": "^5.0",
         "siriusphp/upload": "^2.1",

--- a/symfony.lock
+++ b/symfony.lock
@@ -215,6 +215,9 @@
     "knplabs/knp-menu-bundle": {
         "version": "v2.2.1"
     },
+    "kylekatarnls/update-helper": {
+        "version": "1.1.0"
+    },
     "lakion/mink-debug-extension": {
         "version": "v1.2.3"
     },


### PR DESCRIPTION
It was already included in the dev-requirements, but it broke when building a project. This PR fixes that. 

See also: https://github.com/symfony/symfony/issues/31720
