### PR TITLE
Allow for Carbon 2, alongside Carbon 1 (needed for Symfony 4 requirements)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "league/glide-symfony": "^1.0",
         "miljar/php-exif": "^0.6.4",
         "nelmio/cors-bundle": "^1.5",
-        "nesbot/carbon": "^1.37",
+        "nesbot/carbon": "^1.38 || ^2.19",
         "php-translation/symfony-bundle": "^0.8",
         "phpdocumentor/reflection-docblock": "^4.3",
         "psr/simple-cache": "^1.0",
@@ -94,9 +94,6 @@
         "symplify/easy-coding-standard": "^5.4.14"
     },
     "config": {
-        "platform": {
-            "php": "7.1.3"
-        },
         "preferred-install": {
             "*": "dist"
         },


### PR DESCRIPTION
See: https://github.com/briannesbitt/Carbon/issues/1685