### PR TITLE
Workaround for editing translations in backend

### DIFF
--- a/templates/bundles/TranslationBundle/SymfonyProfiler/translation.html.twig
+++ b/templates/bundles/TranslationBundle/SymfonyProfiler/translation.html.twig
@@ -1,0 +1,192 @@
+{# Temporary workaround, until this patch is in a release:
+   @see: https://github.com/php-translation/symfony-bundle/pull/311
+   @see: https://github.com/bolt/four/issues/506
+   #}
+
+{% extends '@WebProfiler/Collector/translation.html.twig' %}
+
+{#
+ # Authors Tobias Nyholm, Damien Alexandre (damienalexandre), Damien Harper
+ #}
+
+{% import _self as translation_helper %}
+
+{% block panelContent %}
+    <h2>Translation Metrics</h2>
+
+    <div>
+        <a class="btn" href="javascript:void(0);" onclick='syncAll()'>Synchronize all translations</a><br />
+        <div id="top-result-area"></div>
+    </div>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.countdefines }}</span>
+            <span class="label">Defined messages</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ collector.countFallbacks }}</span>
+            <span class="label">Fallback messages</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ collector.countMissings }}</span>
+            <span class="label">Missing messages</span>
+        </div>
+    </div>
+
+    <h2>Translation Messages</h2>
+
+    {# sort translation messages in groups #}
+    {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
+    {% for key, message in collector.messages %}
+        {% if message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_DEFINED') %}
+            {% set messages_defined = messages_defined|merge({(key): message}) %}
+        {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_MISSING') %}
+            {% set messages_missing = messages_missing|merge({(key): message}) %}
+        {% elseif message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK') %}
+            {% set messages_fallback = messages_fallback|merge({(key): message}) %}
+        {% endif %}
+    {% endfor %}
+
+    <form action="{{ path('php_translation_profiler_translation_create_assets', {'token': token}) }}" method="post"
+          id="translations-list" onSubmit="return saveTranslations(this);" >
+    <span class="hidden">
+        <img src="{{ asset("bundles/translation/css/images/loader.svg") }}" width="60" id="svg-loader">
+    </span>
+
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Defined <span class="badge">{{ messages_defined|length }}</span></h3>
+
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are correctly translated into the given locale.
+                    </p>
+
+                    {% if messages_defined is empty %}
+                        <div class="empty">
+                            <p>None of the used translation messages are defined for the given locale.</p>
+                        </div>
+                    {% else %}
+                        {{ translation_helper.render_table(messages_defined) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Fallback <span class="badge">{{ messages_fallback|length }}</span></h3>
+
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are not available for the given locale
+                        but Symfony found them in the fallback locale catalog.
+                    </p>
+
+                    {% if messages_fallback is empty %}
+                        <div class="empty">
+                            <p>No fallback translation messages were used.</p>
+                        </div>
+                    {% else %}
+                        {{ translation_helper.render_table(messages_fallback) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Missing <span class="badge">{{ messages_missing|length }}</span></h3>
+
+                <div class="tab-content">
+                    <p class="help">
+                        These messages are not available for the given locale and cannot
+                        be found in the fallback locales. Add them to the translation
+                        catalogue to avoid Symfony outputting untranslated contents.
+                    </p>
+
+                    {% if messages_missing is empty %}
+                        <div class="empty">
+                            <p>There are no messages of this category.</p>
+                        </div>
+                    {% else %}
+                        {{ translation_helper.render_table(messages_missing, true) }}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <p class="full-width" id="translationResult"></p>
+
+        <button type="submit" class="btn">
+            Add selected messages
+        </button>
+
+    </form>
+    {% include "@Translation/SymfonyProfiler/javascripts.html.twig" %}
+{% endblock %}
+
+{% block panel %}
+    {{ block('panelContent') }}
+{% endblock %}
+
+{% macro render_table(messages, checkedByDefault = false) %}
+    <table>
+        <thead>
+        <tr>
+            <th>
+                <input type="checkbox" id="check-all-control" onchange="toggleCheckAll(this)" {% if checkedByDefault %}checked="checked"{% endif %}>
+            </th>
+            <th>Locale</th>
+            <th>Domain</th>
+            <th>Times used</th>
+            <th>Message ID</th>
+            <th>Message Preview</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for key, message in messages %}
+            <tr id="{{ key }}">
+                <td>
+                    {% if message.state == constant('Symfony\\Component\\Translation\\DataCollectorTranslator::MESSAGE_MISSING') %}
+                        <input type="checkbox" name="translationKey" value="{{ key }}" checked="checked" class="translation-key-checkbox">
+                    {% else %}
+                        <input type="checkbox" disabled="disabled">
+                    {% endif %}
+                </td>
+                <td class="font-normal text-small">{{ message.locale }}</td>
+                <td class="font-normal text-small text-bold nowrap">{{ message.domain }}</td>
+                <td class="font-normal text-small">{{ message.count }}</td>
+                <td>
+                    {{ message.id }}
+
+                    {% if message.transChoiceNumber is not null %}
+                        <small class="newline">(pluralization is used)</small>
+                    {% endif %}
+
+                    {% if message.parameters|length > 0 %}
+                        <button class="btn-link newline text-small sf-toggle" data-toggle-selector="#parameters-{{ loop.index }}" data-toggle-alt-content="Hide parameters">Show parameters</button>
+
+                        <div id="parameters-{{ loop.index }}" class="hidden">
+                            {% for parameters in message.parameters %}
+                                {{ profiler_dump(parameters) }}
+                                {% if not loop.last %}<br />{% endif %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </td>
+                <td class="translation">
+                    {{ message.translation }}
+                </td>
+                <td width="155px">
+                    {% spaceless %}
+                        <a class="edit btn btn-sm" href="javascript:void(0);" onclick='getEditForm("{{ key }}")'>Edit</a>
+                        |
+                        <a class="sync btn btn-sm" href="javascript:void(0);" onclick='syncMessage("{{ key }}")'>Sync</a>
+                    {% endspaceless %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl-NL" trgLang="en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="messages.en">
     <unit id="tbB2gib" name="not_available">
       <notes>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl-NL" trgLang="en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="validators.en">
     <unit id="TG1D5NO" name="post.blank_summary">
       <notes>


### PR DESCRIPTION
Temporary workaround. Revert when https://github.com/php-translation/symfony-bundle/pull/311 is in a release of PHP-Translation.